### PR TITLE
ci: fix tests and workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,4 +31,4 @@ jobs:
         run: npm run build
 
       - name: Run tests
-        run: npm run test --passWithNoTests
+        run: npm test

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,9 +1,14 @@
 import type { Config } from 'jest';
 
 const config: Config = {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testMatch: ['**/tests/**/*.test.ts'],
-  moduleFileExtensions: ['ts', 'js', 'json']
+  moduleFileExtensions: ['ts', 'js', 'json'],
+  extensionsToTreatAsEsm: ['.ts'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1'
+  }
 };
+
 export default config;

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -1,0 +1,11 @@
+import { analyzeHeaders } from '../src/checks/headers';
+
+describe('security-middleware smoke', () => {
+  test('analyzeHeaders returns issues array', () => {
+    const issues = analyzeHeaders({
+      'content-security-policy': "default-src 'self'",
+      'x-frame-options': 'DENY'
+    });
+    expect(Array.isArray(issues)).toBe(true);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,17 @@
 {
-    "compilerOptions": {
-      "target": "ES2021",
-      "module": "ES2022",
-      "moduleResolution": "Bundler",
-      "outDir": "dist",
-      "declaration": true,
-      "strict": true,
-      "esModuleInterop": true,
-      "skipLibCheck": true,
-      "forceConsistentCasingInFileNames": true,
-      "resolveJsonModule": true,
-      "sourceMap": true
-    },
-    "include": ["src", "tests"]
-  }
-  
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "sourceMap": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
Fixes failing CI run caused by jest exiting when no tests were detected and uv/jest config issues.

- Adds minimal smoke test under tests/
- Updates jest config for TS ESM (moduleNameMapper)
- Fixes tsconfig to compile src only and keep dist layout stable
- CI now runs npm test cleanly
