### PR TITLE
ci: allow empty jest suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,4 +31,4 @@ jobs:
         run: npm run build
 
       - name: Run tests
-        run: npm test
+        run: npm test -- --passWithNoTests


### PR DESCRIPTION
CI currently fails if no tests are present (jest exits 1). This updates the workflow to pass  so the build stays green while the project has no test files.