### PR TITLE
CI: don't fail when no Jest tests exist

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "test": "jest",
+    "test": "jest --passWithNoTests",
     "dev:test": "NODE_ENV=test jest --watch",
     "prepublishOnly": "npm run build"
   },


### PR DESCRIPTION
CI currently fails with . Set the npm test script to  so the repo stays green until tests are added.